### PR TITLE
RFC4122 Time-based Version 1 Implementation

### DIFF
--- a/unique_id/include/unique_id/impl/unique_id.h
+++ b/unique_id/include/unique_id/impl/unique_id.h
@@ -43,6 +43,8 @@
     @author Jack O'Quin
  */
 
+#include <ros/ros.h>
+
 #include <boost/uuid/uuid_generators.hpp>
 
 namespace unique_id
@@ -68,6 +70,38 @@ namespace unique_id
 
     /* Instantiate boost URL name UUID generator. */
     static boost::uuids::name_generator genURL(url_namespace_uuid);
+
+    /* Generate RFC4122 Version 1 Time-Based UUID */
+    static boost::uuids::uuid genTime(ros::Time uuid_time, char* hw_addr)
+    {
+      srand(time(NULL));
+
+      // Get no. of 100 nanosecond intervals since 00:00:00 October 15, 1582
+      long unsigned int num_hundred_nano = uuid_time.sec / (1e-9 * 100) +
+                                           uuid_time.nsec / 100 +  122192928000000000;
+
+      uint32_t time_low = static_cast<uint32_t>(num_hundred_nano >> 4);
+      uint16_t time_mid = static_cast<int16_t>(num_hundred_nano >> (32 + 4));
+      uint16_t version = 1 << 15;
+      uint16_t time_hi_and_version = static_cast<int16_t>((num_hundred_nano >> (32 + 16 + 4)) | version);
+
+      // Generate Clock Sequence ID based on random number
+      uint16_t clock_seq_hi_and_reserved = (rand() % (1 << 14)) | 1 << 15;
+
+      boost::uuids::uuid uu = {
+                                static_cast<uint8_t>(time_low >> 24), static_cast<uint8_t>(time_low >> 16),
+                                static_cast<uint8_t>(time_low >> 8),  static_cast<uint8_t>(time_low),
+                                static_cast<uint8_t>(time_mid >> 8),  static_cast<uint8_t>(time_mid),
+                                static_cast<uint8_t>(time_hi_and_version >> 8),
+                                static_cast<uint8_t>(time_hi_and_version),
+                                static_cast<uint8_t>(clock_seq_hi_and_reserved >> 8),
+                                static_cast<uint8_t>(clock_seq_hi_and_reserved),
+                                (uint8_t)hw_addr[0], (uint8_t)hw_addr[1],
+                                (uint8_t)hw_addr[2], (uint8_t)hw_addr[3],
+                                (uint8_t)hw_addr[4], (uint8_t)hw_addr[5]
+                              };
+      return uu;
+    }
 
   } // end namespace impl
 

--- a/unique_id/include/unique_id/unique_id.h
+++ b/unique_id/include/unique_id/unique_id.h
@@ -153,6 +153,19 @@ static inline boost::uuids::uuid fromURL(std::string const &url)
   return impl::genURL(url);
 }
 
+/** @brief Generate a Time Based UUID object.
+ *
+ *  @returns type 1 boost::uuids::uuid object.
+ *
+ *  Different calls to this function at any time or place will almost
+ *  certainly generate different UUIDs. The method used is RFC 4122
+ *  version 1.
+ */
+static inline boost::uuids::uuid fromTime(ros::Time time, char* hw_addr)
+{
+  return impl::genTime(time, hw_addr);
+}
+
 /** @brief Create a UniqueID message from a UUID object.
  *
  *  @param uu boost::uuids::uuid object.


### PR DESCRIPTION
This is an implementation of the RFC4122 Unique Identifies (UUID) implementation as defined in http://www.ietf.org/rfc/rfc4122.txt 