### PR TITLE
RFC4122 Time-Based Version 1 UUID Generation

### DIFF
--- a/unique_id/include/unique_id/impl/unique_id.h
+++ b/unique_id/include/unique_id/impl/unique_id.h
@@ -43,6 +43,8 @@
     @author Jack O'Quin
  */
 
+#include <ros/ros.h>
+
 #include <boost/uuid/uuid_generators.hpp>
 
 namespace unique_id
@@ -51,7 +53,6 @@ namespace unique_id
   /** @brief C++ namespace for private implementation details. */
   namespace impl
   {
-
     /* Instantiate boost string UUID generator. */
     static boost::uuids::string_generator genString;
 
@@ -68,6 +69,44 @@ namespace unique_id
 
     /* Instantiate boost URL name UUID generator. */
     static boost::uuids::name_generator genURL(url_namespace_uuid);
+
+    /* Generate RFC4122 Version 1 Time-Based UUID */
+    static boost::uuids::uuid genTime(ros::Time uuid_time, uint64_t hw_addr)
+    {
+      // Get no. of 100 nanosecond intervals since 00:00:00 October 15, 1582
+      // The RFC4122 standard only requires the least significant 60 bits for timestamp
+
+      // No. of 100 ns intervals between 00:00:00 Oct 15, 1582 and 00:00:00 Jan 1, 1970
+      uint64_t offset = 122192928000000000;
+
+      uint64_t num_hundred_epoch = static_cast<uint64_t>(uuid_time.sec) / (1e-9 * 100) +
+                                   static_cast<uint64_t>(uuid_time.nsec) / 100;
+      // Note: Adding offset in the same line as the above statement may yield incorrect
+      //       values on some systems
+      uint64_t num_hundred_rfc = num_hundred_epoch + offset;
+
+      uint32_t time_low = static_cast<uint32_t>(num_hundred_rfc);
+      uint16_t time_mid = static_cast<uint16_t>(num_hundred_rfc >> 32);
+      uint16_t version = 0x1000;
+      uint16_t time_hi_and_version = static_cast<uint16_t>(num_hundred_rfc >> (32 + 16)) | version;
+
+      // Generate Clock Sequence ID based on random number
+      uint16_t clock_seq_and_reserved = (rand() % (1 << 14)) | 0x8000;
+
+      boost::uuids::uuid uu = {
+                                static_cast<uint8_t>(time_low >> 24), static_cast<uint8_t>(time_low >> 16),
+                                static_cast<uint8_t>(time_low >> 8),  static_cast<uint8_t>(time_low),
+                                static_cast<uint8_t>(time_mid >> 8),  static_cast<uint8_t>(time_mid),
+                                static_cast<uint8_t>(time_hi_and_version >> 8),
+                                static_cast<uint8_t>(time_hi_and_version),
+                                static_cast<uint8_t>(clock_seq_and_reserved >> 8),
+                                static_cast<uint8_t>(clock_seq_and_reserved),
+                                static_cast<uint8_t>(hw_addr >> 40), static_cast<uint8_t>(hw_addr >> 32),
+                                static_cast<uint8_t>(hw_addr >> 24), static_cast<uint8_t>(hw_addr >> 16),
+                                static_cast<uint8_t>(hw_addr >> 8),  static_cast<uint8_t>(hw_addr)
+                              };
+      return uu;
+    }
 
   } // end namespace impl
 

--- a/unique_id/include/unique_id/unique_id.h
+++ b/unique_id/include/unique_id/unique_id.h
@@ -153,6 +153,22 @@ static inline boost::uuids::uuid fromURL(std::string const &url)
   return impl::genURL(url);
 }
 
+/** @brief Generate a Time Based UUID object. Users are recommended to seed the random
+ *         number generator using srand from the calling application to generate the clock_id
+ *
+ *  @param timestamp The ros::Time timestamp for UUID generation
+ *  @param hw_addr A 48-bit (6 octets) network address assigned to the 48 LSBs
+ *  @returns type 1 boost::uuids::uuid object.
+ *
+ *  Different calls to this function at any time or place will almost
+ *  certainly generate different UUIDs. The method used is RFC 4122
+ *  version 1.
+ */
+static inline boost::uuids::uuid fromTime(ros::Time timestamp, uint64_t hw_addr)
+{
+  return impl::genTime(timestamp, hw_addr);
+}
+
 /** @brief Create a UniqueID message from a UUID object.
  *
  *  @param uu boost::uuids::uuid object.

--- a/unique_id/mainpage.dox
+++ b/unique_id/mainpage.dox
@@ -7,4 +7,7 @@ universally unique identifiers.
 
 There are no ROS nodes or commands.
 
+Note: For Time-Based UUID generation using the C++ interface
+      seed the random number generator through srand()
+
 */

--- a/unique_id/src/unique_id/__init__.py
+++ b/unique_id/src/unique_id/__init__.py
@@ -106,6 +106,26 @@ def fromURL(url):
     """
     return uuid.uuid5(uuid.NAMESPACE_URL, url)
 
+def fromTime(timestamp, hw_addr):
+    """Generate a Time Based UUID object.
+
+    :param timestamp: The rospy.Time timestamp for UUID generation
+    :param hw_addr: A 48-bit long representing the network address
+    :returns: type 1 :class:`uuid.UUID` object
+
+    Different calls to this function at any time or place will almost
+    certainly generate different UUIDs. The method used is RFC 4122
+    version 1.
+    """
+    uu = uuid.uuid1(hw_addr)
+    offset = 122192928000000000
+    nano_epoch = long(timestamp.secs / (100 * 1e-9) + timestamp.nsecs / 100)
+    # return nano_epoch
+    nano_rfc = nano_epoch + offset
+    data = (nano_rfc & 0x0000000FFFFFFFF, (nano_rfc >> 32) & 0x000FFFF, (nano_rfc >> 48) | 0x1000,
+            uu.fields[3], uu.fields[4], uu.fields[5])
+    return uuid.UUID(fields=data)
+
 def toMsg(uuid_obj):
     """Create a UniqueID message from a UUID object.
 

--- a/unique_id/tests/test_unique_id.cpp
+++ b/unique_id/tests/test_unique_id.cpp
@@ -1,10 +1,11 @@
 //
 // C++ unit tests for unique_id interface.
 //
-
 #include <gtest/gtest.h>
 
+#include <ros/ros.h>
 #include <unique_id/unique_id.h>
+
 using namespace unique_id;
 typedef boost::uuids::uuid uuid;
 typedef uuid_msgs::UniqueID UniqueID;
@@ -26,6 +27,134 @@ TEST(BoostUUID, fromRandom)
           EXPECT_NE(uu[i], uu[j]);
         }
     }
+}
+
+// Test Timebased UUID
+TEST(BoostUUID, fromTime)
+{
+  ros::Time t(1515778146, 239216089);
+  uint64_t hw_addr = 0xAABBCCDDEEFF;
+
+  // Generate UUID from time and hardware address
+  uuid uu = fromTime(t, hw_addr);
+
+  // Obtain time since epoch back from the generated uuid
+  std::vector<uint8_t> data(uu.size());
+  std::copy(uu.begin(), uu.end(), data.begin());
+
+  uint64_t timestamp = (static_cast<uint64_t>(data[0]) << 24) + (static_cast<uint64_t>(data[1]) << 16) +
+                       (static_cast<uint64_t>(data[2]) << 8) + static_cast<uint64_t>(data[3]) +
+                       (static_cast<uint64_t>(data[4]) << 40) + (static_cast<uint64_t>(data[5]) << 32) +
+                       (static_cast<uint64_t>(data[6] & 0x0F) << 56) + (static_cast<uint64_t>(data[7]) << 48);
+  uint64_t offset = 122192928000000000;  // time offset in 100 ns intervals between RFC4122 Timestamp and Epoch Time
+  uint64_t ns_intervals = timestamp - offset;
+  uint64_t uu_hw_addr = 0;
+  for (int8_t i=0; i < 6; i++)
+  {
+    uu_hw_addr += static_cast<uint64_t>(data[uu.size() - 1 - i]) << 8*i;
+  }
+
+  ros::Time uu_time;
+  uu_time.sec = static_cast<int32_t>(ns_intervals / 1e9 * 100);
+  uu_time.nsec = static_cast<int32_t>((ns_intervals - static_cast<uint64_t>(uu_time.sec) / (100 * 1e-9)) * 100);
+
+  EXPECT_EQ(t.sec, uu_time.sec);
+  // The UUID stores the timestamp in 100ns intervals,
+  // so we lose precision for the 1's and 10's value of the nanoseconds in the time given
+  EXPECT_EQ(t.nsec - uu_time.nsec, 89);
+  EXPECT_EQ(hw_addr, uu_hw_addr);
+}
+
+TEST(BoostUUID, timeWithinSameInterval)
+{
+  ros::Time t1(1515778146, 239216020);
+  ros::Time t2(1515778146, 239216080);
+  uint64_t hw_addr = 0xAABBCCDDEEFF;
+
+  // Generate UUIDs from times and hardware address
+  uuid uu1 = fromTime(t1, hw_addr);
+  uuid uu2 = fromTime(t2, hw_addr);
+
+  // Obtain times since epoch back from uu1
+  std::vector<uint8_t> data(uu1.size());
+  std::copy(uu1.begin(), uu1.end(), data.begin());
+
+  uint64_t timestamp = (static_cast<uint64_t>(data[0]) << 24) + (static_cast<uint64_t>(data[1]) << 16) +
+                       (static_cast<uint64_t>(data[2]) << 8) + static_cast<uint64_t>(data[3]) +
+                       (static_cast<uint64_t>(data[4]) << 40) + (static_cast<uint64_t>(data[5]) << 32) +
+                       (static_cast<uint64_t>(data[6] & 0x0F) << 56) + (static_cast<uint64_t>(data[7]) << 48);
+  uint64_t offset = 122192928000000000;  // time offset in 100 ns intervals between RFC4122 Timestamp and Epoch Time
+  uint64_t ns_intervals = timestamp - offset;
+
+  ros::Time uu1_time;
+  uu1_time.sec = static_cast<int32_t>(ns_intervals / 1e9 * 100);
+  uu1_time.nsec = static_cast<int32_t>((ns_intervals - static_cast<uint64_t>(uu1_time.sec) / (100 * 1e-9)) * 100);
+
+  // Obtain times since epoch back from uu2
+  std::copy(uu2.begin(), uu2.end(), data.begin());
+
+  timestamp = (static_cast<uint64_t>(data[0]) << 24) + (static_cast<uint64_t>(data[1]) << 16) +
+              (static_cast<uint64_t>(data[2]) << 8) + static_cast<uint64_t>(data[3]) +
+              (static_cast<uint64_t>(data[4]) << 40) + (static_cast<uint64_t>(data[5]) << 32) +
+              (static_cast<uint64_t>(data[6] & 0x0F) << 56) + (static_cast<uint64_t>(data[7]) << 48);
+  ns_intervals = timestamp - offset;
+
+  ros::Time uu2_time;
+  uu2_time.sec = static_cast<int32_t>(ns_intervals / 1e9 * 100);
+  uu2_time.nsec = static_cast<int32_t>((ns_intervals - static_cast<uint64_t>(uu2_time.sec) / (100 * 1e-9)) * 100);
+
+  // Compare
+  // Since both timestamps were in the same 100ns interval, should get same timestamp
+  EXPECT_EQ(uu1_time.sec, uu2_time.sec);
+  EXPECT_EQ(uu1_time.nsec, uu2_time.nsec);
+
+  // While timestamps are the same, the clock_id is a randomly generated 14-bit value
+  // So, we should still expect the uuids generated to be different
+  EXPECT_NE(uu1, uu2);
+}
+
+TEST(BoostUUID, timeWithinDifferentInterval)
+{
+  ros::Time t1(1515778146, 239216020);
+  ros::Time t2(1515778146, 239216120);
+  uint64_t hw_addr = 0xAABBCCDDEEFF;
+
+  // Generate UUIDs from times and hardware address
+  uuid uu1 = fromTime(t1, hw_addr);
+  uuid uu2 = fromTime(t2, hw_addr);
+
+  // Obtain times since epoch back from uu1
+  std::vector<uint8_t> data(uu1.size());
+  std::copy(uu1.begin(), uu1.end(), data.begin());
+
+  uint64_t timestamp = (static_cast<uint64_t>(data[0]) << 24) + (static_cast<uint64_t>(data[1]) << 16) +
+                       (static_cast<uint64_t>(data[2]) << 8) + static_cast<uint64_t>(data[3]) +
+                       (static_cast<uint64_t>(data[4]) << 40) + (static_cast<uint64_t>(data[5]) << 32) +
+                       (static_cast<uint64_t>(data[6] & 0x0F) << 56) + (static_cast<uint64_t>(data[7]) << 48);
+  uint64_t offset = 122192928000000000;  // time offset in 100 ns intervals between RFC4122 Timestamp and Epoch Time
+  uint64_t ns_intervals = timestamp - offset;
+
+  ros::Time uu1_time;
+  uu1_time.sec = static_cast<int32_t>(ns_intervals / 1e9 * 100);
+  uu1_time.nsec = static_cast<int32_t>((ns_intervals - static_cast<uint64_t>(uu1_time.sec) / (100 * 1e-9)) * 100);
+
+  // Obtain times since epoch back from uu2
+  std::copy(uu2.begin(), uu2.end(), data.begin());
+
+  timestamp = (static_cast<uint64_t>(data[0]) << 24) + (static_cast<uint64_t>(data[1]) << 16) +
+              (static_cast<uint64_t>(data[2]) << 8) + static_cast<uint64_t>(data[3]) +
+              (static_cast<uint64_t>(data[4]) << 40) + (static_cast<uint64_t>(data[5]) << 32) +
+              (static_cast<uint64_t>(data[6] & 0x0F) << 56) + (static_cast<uint64_t>(data[7]) << 48);
+  ns_intervals = timestamp - offset;
+
+  ros::Time uu2_time;
+  uu2_time.sec = static_cast<int32_t>(ns_intervals / 1e9 * 100);
+  uu2_time.nsec = static_cast<int32_t>((ns_intervals - static_cast<uint64_t>(uu2_time.sec) / (100 * 1e-9)) * 100);
+
+  // Compare
+  // Since both timestamps were in different 100ns intervals, should get different timestamps (at the ns level)
+  EXPECT_EQ(uu1_time.sec, uu2_time.sec);
+  EXPECT_NE(uu1_time.nsec, uu2_time.nsec);
 }
 
 TEST(BoostUUID, emptyURL)

--- a/unique_id/tests/test_unique_id.py
+++ b/unique_id/tests/test_unique_id.py
@@ -9,6 +9,7 @@ import unittest
 
 import uuid                     # standard Python module
 
+import rospy
 from uuid_msgs.msg import UniqueID
 from unique_id import *
 
@@ -121,6 +122,80 @@ class TestPythonUUID(unittest.TestCase):
         y = toHexString(x)
         self.assertEqual(s, y)
         self.assertEqual(type(y), str)
+
+    # UUID Time-Based Generation
+    def test_time(self):
+        hw_addr = 0xAABBCCDDEEFF
+        t = rospy.Time(1515778146, 239216089)
+        uu = fromTime(t, hw_addr)  # generate UUID
+        offset = 122192928000000000  # in 100ns intervals between RFC4122 timestamp and epoch time
+        ns_intervals_rfc = uu.fields[0] + (uu.fields[1] << 32) + ((uu.fields[2] & 0x0FFF) << 48)
+        ns_intervals_epoch = ns_intervals_rfc - offset
+        uu_time = rospy.Time()
+        uu_time.secs = long(ns_intervals_epoch / 1e9 * 100)
+        uu_time.nsecs = long(ns_intervals_epoch - uu_time.secs / (100 * 1e-9)) * 100
+
+        self.assertEqual(t.secs, uu_time.secs)
+        # Expect 89ns to be shaved off due to timestamp being stored in 100ns intervals
+        self.assertEqual(t.nsecs - uu_time.nsecs, 89)
+        # Should be able to retrieve the hardware id
+        self.assertEqual(hw_addr, uu.fields[5])
+
+    def test_time_same_interval(self):
+        hw_addr = 0xAABBCCDDEEFF
+        t1 = rospy.Time(1515778146, 239216020)
+        t2 = rospy.Time(1515778146, 239216080)
+        uu1 = fromTime(t1, hw_addr)  # generate UUID for t1
+        uu2 = fromTime(t2, hw_addr)  # generate UUID for t2
+        offset = 122192928000000000  # in 100ns intervals between RFC4122 timestamp and epoch time
+
+        # Get time associated with uuid uu1
+        ns_intervals_rfc = uu1.fields[0] + (uu1.fields[1] << 32) + ((uu1.fields[2] & 0x0FFF) << 48)
+        ns_intervals_epoch = ns_intervals_rfc - offset
+        uu1_time = rospy.Time()
+        uu1_time.secs = long(ns_intervals_epoch / 1e9 * 100)
+        uu1_time.nsecs = long(ns_intervals_epoch - uu1_time.secs / (100 * 1e-9)) * 100
+
+        # Get time associated with uuid uu2
+        ns_intervals_rfc = uu2.fields[0] + (uu2.fields[1] << 32) + ((uu2.fields[2] & 0x0FFF) << 48)
+        ns_intervals_epoch = ns_intervals_rfc - offset
+        uu2_time = rospy.Time()
+        uu2_time.secs = long(ns_intervals_epoch / 1e9 * 100)
+        uu2_time.nsecs = long(ns_intervals_epoch - uu2_time.secs / (100 * 1e-9)) * 100
+
+        self.assertEqual(uu1_time.secs, uu2_time.secs)
+        # Timestamps should be same as they were generated for timestamps in the same 100ns interval
+        self.assertEqual(uu1_time.nsecs, uu2_time.nsecs)
+        # UUIDs should be different due to different (hopefully) randomly generated 14-bit clock ids 
+        self.assertNotEqual(uu1, uu2)
+
+    def test_time_different_interval(self):
+        hw_addr = 0xAABBCCDDEEFF
+        t1 = rospy.Time(1515778146, 239216020)
+        t2 = rospy.Time(1515778146, 239216120)
+        uu1 = fromTime(t1, hw_addr)  # generate UUID for t1
+        uu2 = fromTime(t2, hw_addr)  # generate UUID for t2
+        offset = 122192928000000000  # in 100ns intervals between RFC4122 timestamp and epoch time
+
+        # Get time associated with uuid uu1
+        ns_intervals_rfc = uu1.fields[0] + (uu1.fields[1] << 32) + ((uu1.fields[2] & 0x0FFF) << 48)
+        ns_intervals_epoch = ns_intervals_rfc - offset
+        uu1_time = rospy.Time()
+        uu1_time.secs = long(ns_intervals_epoch / 1e9 * 100)
+        uu1_time.nsecs = long(ns_intervals_epoch - uu1_time.secs / (100 * 1e-9)) * 100
+
+        # Get time associated with uuid uu2
+        ns_intervals_rfc = uu2.fields[0] + (uu2.fields[1] << 32) + ((uu2.fields[2] & 0x0FFF) << 48)
+        ns_intervals_epoch = ns_intervals_rfc - offset
+        uu2_time = rospy.Time()
+        uu2_time.secs = long(ns_intervals_epoch / 1e9 * 100)
+        uu2_time.nsecs = long(ns_intervals_epoch - uu2_time.secs / (100 * 1e-9)) * 100
+
+        # Timestamps were generated for the same second
+        self.assertEqual(uu1_time.secs, uu2_time.secs)
+        # Timestamps should be different as they were generated for times in different 100ns intervals
+        self.assertNotEqual(uu1_time.nsecs, uu2_time.nsecs)
+
 
 if __name__ == '__main__':
     import rosunit


### PR DESCRIPTION
* This provides an implementation for the RFC4122 Time-Based Version 1 Standard as described https://tools.ietf.org/html/rfc4122#section-4.2