### PR TITLE
clean cmake and package.xml for uuid_msgs

### DIFF
--- a/uuid_msgs/CMakeLists.txt
+++ b/uuid_msgs/CMakeLists.txt
@@ -1,38 +1,28 @@
 cmake_minimum_required(VERSION 3.5)
 project(uuid_msgs)
 
-# Add support for C++11
+# Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
 
-find_package(std_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME} "msg/UniqueID.msg"
-  DEPENDENCIES builtin_interfaces std_msgs)
+set(msg_files
+  "msg/UniqueID.msg"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  DEPENDENCIES std_msgs
+)
 
-set(INCLUDE_DIRS ${std_msgs_INCLUDE_DIRS} ${ament_cmake_INCLUDE_DIRS}
-  ${rosidl_default_generators_INCLUDE_DIRS})
-include_directories(${INCLUDE_DIRS})
-
-set(LIBRARY_DIRS ${std_msgs_LIBRARY_DIRS} ${ament_cmake_LIBRARY_DIRS}
-  ${rosidl_default_generators_LIBRARY_DIRS})
-
-link_directories(${LIBRARY_DIRS})
-
-set(LIBS ${std_msgs_LIBRARIES} ${ament_cmake_LIBRARIES}
-  ${rosidl_default_generators_LIBRARIES})
-
-# We want boost/format.hpp, which isn't in its own component.
-find_package(Boost REQUIRED)
-
-ament_export_dependencies(std_msgs)
-ament_export_dependencies(ament_cmake)
-ament_export_dependencies(rosidl_default_generators)
-ament_export_include_directories(${INCLUDE_DIRS})
+ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()

--- a/uuid_msgs/package.xml
+++ b/uuid_msgs/package.xml
@@ -1,4 +1,5 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
 
   <name>uuid_msgs</name>
@@ -13,16 +14,16 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
   <depend>std_msgs</depend>
 
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
   <export>
-    <architecture_independent />
     <build_type>ament_cmake</build_type>
   </export>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
- <buildtool_depend>rosidl_default_generators</buildtool_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
-  </package>
+</package>


### PR DESCRIPTION
I came across this when trying to compile that repository with ROS 2.

This is mostly simplifying the CMake logic for the message package.

I didn't target making `unique_id` compile as this is a pretty unrelated change and will make reviewing more difficult.

@matt-attack as the original contributor of the ROS2 port, can you confirm that this still works for your use case?