### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/unique_id/package.xml
+++ b/unique_id/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
 
   <name>unique_id</name>
   <version>1.0.6</version>

--- a/unique_id/package.xml
+++ b/unique_id/package.xml
@@ -13,6 +13,8 @@
   <url>http://ros.org/wiki/unique_id</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <depend>roscpp</depend>
   <depend>rospy</depend>

--- a/unique_id/setup.py
+++ b/unique_id/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/unique_identifier/package.xml
+++ b/unique_identifier/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
 
   <name>unique_identifier</name>
   <version>1.0.6</version>

--- a/uuid_msgs/package.xml
+++ b/uuid_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
 
   <name>uuid_msgs</name>
   <version>1.0.6</version>


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.